### PR TITLE
Bump version to 0.2.1 and enhance Chromium availability checks in the…

### DIFF
--- a/ha-screenshotter/config.yaml
+++ b/ha-screenshotter/config.yaml
@@ -1,6 +1,6 @@
 # Home Assistant Add-on Configuration
 name: "HA Screenshotter"
-version: "0.2.0"
+version: "0.2.1"
 slug: "ha-screenshotter"
 description: "Takes screenshots of web pages on a configurable schedule"
 url: "https://github.com/jantielens/ha-screenshotter"

--- a/ha-screenshotter/index.js
+++ b/ha-screenshotter/index.js
@@ -24,7 +24,23 @@ async function takeScreenshot(url, filename) {
   
   let browser = null;
   try {
-    // Launch Puppeteer with Alpine/Chromium specific configuration
+    // Check if Chromium is available
+    const fs = require('fs');
+    if (!fs.existsSync('/usr/bin/chromium-browser')) {
+      throw new Error('Chromium browser not found at /usr/bin/chromium-browser');
+    }
+    console.log('✅ Chromium browser found');
+    
+    // Log system info for debugging
+    console.log('🖥️  System info:', {
+      platform: process.platform,
+      arch: process.arch,
+      nodeVersion: process.version,
+      memory: Math.round(process.memoryUsage().heapUsed / 1024 / 1024) + 'MB'
+    });
+    
+    // Launch Puppeteer with minimal configuration first
+    console.log('🚀 Launching browser...');
     browser = await puppeteer.launch({
       executablePath: '/usr/bin/chromium-browser',
       headless: 'new',
@@ -32,13 +48,12 @@ async function takeScreenshot(url, filename) {
         '--no-sandbox',
         '--disable-setuid-sandbox',
         '--disable-dev-shm-usage',
-        '--disable-accelerated-2d-canvas',
-        '--no-first-run',
-        '--no-zygote',
-        '--single-process',
-        '--disable-gpu'
+        '--disable-gpu',
+        '--no-first-run'
       ]
     });
+    
+    console.log('✅ Browser launched successfully');
 
     const page = await browser.newPage();
     
@@ -113,7 +128,17 @@ async function init() {
       console.log('🎊 Screenshot test successful!');
     } catch (screenshotError) {
       console.error('⚠️  Screenshot test failed:', screenshotError.message);
-      // Don't exit on screenshot failure, just log it
+      console.log('🔄 Trying with simpler URL...');
+      
+      // Try a simpler fallback URL
+      try {
+        const fallbackFilename = `example-${timestamp}.png`;
+        await takeScreenshot('https://example.com', fallbackFilename);
+        console.log('🎊 Fallback screenshot test successful!');
+      } catch (fallbackError) {
+        console.error('⚠️  Fallback screenshot also failed:', fallbackError.message);
+        console.log('ℹ️  This might be due to container restrictions, but the add-on will continue running');
+      }
     }
     
     console.log('✨ Add-on is running successfully');

--- a/ha-screenshotter/package.json
+++ b/ha-screenshotter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-screenshotter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Home Assistant add-on that takes screenshots of web pages on a configurable schedule",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This pull request updates the HA Screenshotter add-on to improve reliability and diagnostics, especially around launching the Chromium browser and handling screenshot failures. The most important changes include enhanced error handling, better logging for debugging, and a fallback mechanism if initial screenshot attempts fail.

**Diagnostics and reliability improvements:**

* Added a check to ensure Chromium is available at `/usr/bin/chromium-browser` before attempting to launch, with clear error messaging if not found.
* Added detailed system information and progress logs to aid in debugging browser launch issues.

**Error handling enhancements:**

* If the initial screenshot attempt fails, the code now tries to capture a screenshot of a simpler fallback URL (`https://example.com`) and logs the result, helping to distinguish between configuration issues and broader environment/container restrictions.

**Configuration and versioning:**

* Bumped the add-on version to `0.2.1` in both `config.yaml` and `package.json` to reflect these improvements. [[1]](diffhunk://#diff-0bc92ea3915e6effa676e1e96e160b89ea7c9e96d3446e49e5158e28d92ff6edL3-R3) [[2]](diffhunk://#diff-982457f0a20477aa76accf12a1c93c6d32bb7b16a9e611f10d6615de96b68197L3-R3)