### PR TITLE
Enhance CRC32 history view with change highlighting

### DIFF
--- a/ha-screenshotter/CHANGELOG.md
+++ b/ha-screenshotter/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.19.0] - 2025-10-18
+
+### Changed
+- **CRC32 history modal** now highlights checksum change runs with rotating color stripes and "Changed" badges for immediate visual cues
+- Duplicate CRC32 entries are dimmed and display consolidated timestamp ranges to clarify how long a checksum remained unchanged
+
 ## [1.18.0] - 2025-10-18
 
 ### Added

--- a/ha-screenshotter/config.yaml
+++ b/ha-screenshotter/config.yaml
@@ -1,6 +1,6 @@
 # Home Assistant Add-on Configuration
 name: "HA Screenshotter"
-version: "1.18.0"
+version: "1.19.0"
 slug: "ha-screenshotter"
 description: "Takes screenshots of web pages on a configurable schedule with rotation, grayscale, and bit depth support"
 url: "https://github.com/jantielens/ha-screenshotter"

--- a/ha-screenshotter/package.json
+++ b/ha-screenshotter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-screenshotter",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Home Assistant add-on that takes screenshots of web pages on a configurable schedule",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- add client-side grouping of CRC32 history entries and highlight change runs with rotating accent stripes
- dim duplicate rows, show "Changed" badges, and include timestamp spans per run for easier scanning
- bump add-on version to 1.19.0 and document the UI improvements in the changelog

## Testing
- not run

Closes #66.