### PR TITLE
Feature/history index filename and sorting

### DIFF
--- a/ha-screenshotter/CHANGELOG.md
+++ b/ha-screenshotter/CHANGELOG.md
@@ -1,10 +1,14 @@
-# Changelog
-
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.22.0] - 2025-10-20
+
+### Changed
+- History files are now prefixed with the URL index (e.g., url001-YYYYMMDD-HHMMSS-...) for easier tracking and debugging.
+- The /history web page now sorts files by filename in descending order, showing the newest/highest-indexed files first.
+- Fixed SimHash text extraction for Home Assistant dashboards by reverting to the robust extraction algorithm from v1.20.4 (dedicated textExtractor.js).
 
 ## [1.21.1] - 2025-10-20
 
@@ -152,7 +156,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Webserver CI tests** enhanced with CRC32 history endpoint validation
-  - Added test for `/checksums` endpoint to verify current checksums for all screenshots
+  - Added test for `/checksums` endpoint to verify current CRC32 values for all screenshots
   - Added test for `/checksums/:index` endpoint to verify historical data retrieval
   - Validates JSON structure, required fields, and history length settings
 

--- a/ha-screenshotter/config.yaml
+++ b/ha-screenshotter/config.yaml
@@ -1,6 +1,6 @@
 # Home Assistant Add-on Configuration
 name: "HA Screenshotter"
-version: "1.21.1"
+version: "1.22.0"
 slug: "ha-screenshotter"
 description: "Takes screenshots of web pages on a configurable schedule with rotation, grayscale, and bit depth support"
 url: "https://github.com/jantielens/ha-screenshotter"

--- a/ha-screenshotter/package.json
+++ b/ha-screenshotter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ha-screenshotter",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "description": "Home Assistant add-on that takes screenshots of web pages on a configurable schedule",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This pull request introduces version 1.22.0 of the `ha-screenshotter` project, focusing on improvements to history file management, web interface usability, and dashboard text extraction reliability. The changes also include updates to version numbers and documentation.

History and web interface improvements:
* History files are now prefixed with the URL index (e.g., `url001-YYYYMMDD-HHMMSS-...`) to make tracking and debugging easier. (`ha-screenshotter/CHANGELOG.md`)
* The `/history` web page now sorts files by filename in descending order, displaying the newest and highest-indexed files first for better usability. (`ha-screenshotter/CHANGELOG.md`)

Dashboard extraction reliability:
* Fixed SimHash text extraction for Home Assistant dashboards by reverting to the robust extraction algorithm from v1.20.4 (`textExtractor.js`). (`ha-screenshotter/CHANGELOG.md`)

Documentation and versioning updates:
* Updated version numbers to `1.22.0` in `config.yaml` and `package.json`. (`ha-screenshotter/config.yaml`, `ha-screenshotter/package.json`) [[1]](diffhunk://#diff-0bc92ea3915e6effa676e1e96e160b89ea7c9e96d3446e49e5158e28d92ff6edL3-R3) [[2]](diffhunk://#diff-982457f0a20477aa76accf12a1c93c6d32bb7b16a9e611f10d6615de96b68197L3-R3)
* Clarified that webserver CI tests for the `/checksums` endpoint now validate CRC32 values instead of generic checksums. (`ha-screenshotter/CHANGELOG.md`)